### PR TITLE
rf(py314): Replace deprecated pkgutil.find_loader

### DIFF
--- a/src/fmripost_phase/cli/parser.py
+++ b/src/fmripost_phase/cli/parser.py
@@ -522,9 +522,9 @@ def parse_args(args=None, namespace=None):
     config.from_dict(vars(opts), init=['nipype'])
 
     if not config.execution.notrack:
-        import pkgutil
+        import importlib.util
 
-        if pkgutil.find_loader('sentry_sdk') is None:
+        if importlib.util.find_spec('sentry_sdk') is None:
             config.execution.notrack = True
             config.loggers.cli.warning('Telemetry disabled because sentry_sdk is not installed.')
         else:


### PR DESCRIPTION
This PR removes [pkgutil.find_loader()][] and replaces it with [importlib.util.find_spec()][]. `find_loader` was deprecated in Python 3.12 and will be removed in 3.14. `find_spec` has been present since Python 3.4.

Both functions return `None` if the module loader cannot be found. For its use in this project, this is sufficient and no translation of the return value is needed.

[pkgutil.find_loader()]: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_loader
[importlib.util.find_spec()]: https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
